### PR TITLE
Typescript: handle nonoverlapping type

### DIFF
--- a/test/setupJest.ts
+++ b/test/setupJest.ts
@@ -1,6 +1,6 @@
 import { GlobalWithFetchMock } from 'jest-fetch-mock';
 
-const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
+const customGlobal: GlobalWithFetchMock = global as unknown as GlobalWithFetchMock;
 /* tslint:disable-next-line:no-var-requires */
 customGlobal.fetch = require('jest-fetch-mock');
 customGlobal.fetchMock = customGlobal.fetch;


### PR DESCRIPTION
# why

`global` is originally of type `Global & typeof globalThis` and cannot be coerced to `GlobalWithFetchMock` without first converting to `unknown`

# error
```
test/setupJest.ts:3:43 - error TS2352: Conversion of type 'Global & typeof globalThis' to type 'GlobalWithFetchMock' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
      Property 'fetchMock' is missing in type 'Global & typeof globalThis' but required in type 'GlobalWithFetchMock'.

    3 const customGlobal: GlobalWithFetchMock = global as GlobalWithFetchMock;
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

      node_modules/jest-fetch-mock/types/index.d.ts:15:5
        15     fetchMock: FetchMock;
               ~~~~~~~~~
        'fetchMock' is declared here.

```
# repro
0. checkout original template
1. `yarn` (install deps)
2. `yarn test` 