### PR TITLE
Tests: fix response value

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -30,7 +30,7 @@ describe('worker', () => {
     const response = await self.trigger('fetch', request);
 
     expect(fetchMock).toBeCalledTimes(1);
-    expect(response[0].status).toBe(200);
-    expect(await response[0].text()).toBe('Hello');
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('Hello');
   });
 });


### PR DESCRIPTION
# why

The `response` variable is an object of type Response, not an array.

# error
```
    test/index.test.ts:33:12 - error TS7053: Element implicitly has an 'any' type because expression of type '0' can't be used to index type 'Response'.
      Property '0' does not exist on type 'Response'.

    33     expect(response[0].status).toBe(200);
                  ~~~~~~~~~~~
    test/index.test.ts:34:18 - error TS7053: Element implicitly has an 'any' type because expression of type '0' can't be used to index type 'Response'.
      Property '0' does not exist on type 'Response'.

    34     expect(await response[0].text()).toBe('Hello');
```

# repro
0. checkout original template
1. `yarn` (install deps)
2. apply other fix in https://github.com/udacity/cloudflare-typescript-worker-template/pull/1
2. `yarn test` 